### PR TITLE
Delete IndexField.vue

### DIFF
--- a/resources/js/components/IndexField.vue
+++ b/resources/js/components/IndexField.vue
@@ -1,9 +1,0 @@
-<template>
-    <span>{{ field.value }}</span>
-</template>
-
-<script>
-export default {
-    props: ['resourceName', 'field'],
-}
-</script>


### PR DESCRIPTION
Nova default markdown field don't show on index view. It doesn't make sense to do so after all.

Not quite sure how to change the Detail and Form view to behave the same way as Nova default ones. But you can look at them in

vendor/laravel/nova/resources/js/components/Form/MarkdownField.vue

vendor/laravel/nova/resources/js/components/Detail/MarkdownField.vue