### PR TITLE
Added the option to use a random filename when uploading and image

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ Default: `85`
 
 Uploaded images will be converted to this quality. Integer between 0 and 100. Use null to disable quality adjustments.
 
+**Random Filename**
+
+Config key: `random_filename`  
+ENV: `NOVA_MARKDOWN_RANDOM_FILENAME`  
+Default: `false`
+
+Uploaded images will be stored by default using a slug version of its original filename. You can set this to true to use a random filename instead.
+
 ## Security
 If you discover any security related issues, please email [dinand@dcreative.nl](mailto:dinand@dcreative.nl) instead of using the issue tracker.
 

--- a/src/Http/Controllers/UploadController.php
+++ b/src/Http/Controllers/UploadController.php
@@ -104,7 +104,7 @@ class UploadController extends Controller
         $pathinfo = pathinfo($path);
 
         return
-            Str::slug($pathinfo["filename"]) .
+            Str::slug(config("nova-markdown.random_filename") ? Str::random(32) : $pathinfo["filename"]) .
             "." .
             $pathinfo["extension"];
     }

--- a/src/config/nova-markdown.php
+++ b/src/config/nova-markdown.php
@@ -74,4 +74,11 @@ return [
 
     'middleware' => config("nova.middleware"),
 
+    /**
+     * Uploaded images will be stored by default using a slug version of its original filename.
+     * But you can set this to true to use of a random filename.
+     */
+
+    'random_filename' => env("NOVA_MARKDOWN_RANDOM_FILENAME", false),
+
 ];


### PR DESCRIPTION
I was needing to use a custom filename when uploading the image to prevent undesired overwritten.
This is a fast solution but I consider that a custom call for this safeFilename method should be great.