### PR TITLE
Make the "visibility" option for uploaded images configurable.

### DIFF
--- a/src/Http/Controllers/UploadController.php
+++ b/src/Http/Controllers/UploadController.php
@@ -37,7 +37,7 @@ class UploadController extends Controller
         return config("nova-markdown.disk");
     }
 
-    private function uploadsVisibility(): String
+    private function fileVisibility(): String
     {
         return config("nova-markdown.file-visibility");
     }
@@ -68,7 +68,7 @@ class UploadController extends Controller
             $this->safeFilename($file->getClientOriginalName()),
             [
                 "disk" => $this->disk(),
-                "visibility" => $this->uploadsVisibility(),
+                "visibility" => $this->fileVisibility(),
             ],
         );
     }

--- a/src/Http/Controllers/UploadController.php
+++ b/src/Http/Controllers/UploadController.php
@@ -37,6 +37,11 @@ class UploadController extends Controller
         return config("nova-markdown.disk");
     }
 
+    private function uploadsVisibility(): String
+    {
+        return config("nova-markdown.file-visibility");
+    }
+
     private function maxWidth(): ?Int
     {
         return config("nova-markdown.max-width");
@@ -61,7 +66,10 @@ class UploadController extends Controller
         return $file->storeAs(
             $this->directory(),
             $this->safeFilename($file->getClientOriginalName()),
-            $this->disk()
+            [
+                "disk" => $this->disk(),
+                "visibility" => $this->uploadsVisibility(),
+            ],
         );
     }
 

--- a/src/config/nova-markdown.php
+++ b/src/config/nova-markdown.php
@@ -33,6 +33,16 @@ return [
     'disk' => env("NOVA_MARKDOWN_DISK", 'public'),
 
     /**
+     * The visibility option when storing uploaded images.
+     *
+     * Files may either be declared "public" or "private". When a file is declared
+     * "public", you are indicating that the file should generally be accessible
+     * to others.
+     */
+
+    'file-visibility' => env("NOVA_MARKDOWN_FILE_VISIBILITY", 'public'),
+
+    /**
      * The directory where to place uploaded images within the disk.
      *
      * Can be a string with the directoryname. Alternatively, it's possible


### PR DESCRIPTION
For images on a "s3" disk to be accessible via url, the "visibility" option should be set to "public". ([Reference](https://laravel.com/docs/9.x/filesystem#file-visibility))

Now the images upload should work for the environments with an "s3" storage disk out of the box as well